### PR TITLE
fix: use {% element p %} instead of raw <p> HTML tags.

### DIFF
--- a/allauth/templates/mfa/index.html
+++ b/allauth/templates/mfa/index.html
@@ -46,11 +46,11 @@
             {% endslot %}
             {% slot body %}
                 {% if authenticators.webauthn|length %}
-                    <p>
+                    {% element p %}
                         {% blocktranslate count count=authenticators.webauthn|length %}You have added {{ count }} security key.{% plural %}You have added {{ count }} security keys.{% endblocktranslate %}
-                    </p>
+                    {% endelement %}
                 {% else %}
-                    <p>{% translate "No security keys have been added." %}</p>
+                    {% element p %}{% translate "No security keys have been added." %}{% endelement %}
                 {% endif %}
             {% endslot %}
             {% slot actions %}

--- a/allauth/templates/mfa/webauthn/authenticator_confirm_delete.html
+++ b/allauth/templates/mfa/webauthn/authenticator_confirm_delete.html
@@ -5,7 +5,7 @@
     {% element h1 %}
         {% trans "Remove Security Key" %}
     {% endelement %}
-    <p>{% blocktranslate %}Are you sure you want to remove this security key?{% endblocktranslate %}</p>
+    {% element p %}{% blocktranslate %}Are you sure you want to remove this security key?{% endblocktranslate %}{% endelement %}
     {% url 'mfa_remove_webauthn' pk=authenticator.pk as action_url %}
     {% element form method="post" action=action_url no_visible_fields=True %}
         {% slot actions %}

--- a/allauth/templates/mfa/webauthn/authenticator_list.html
+++ b/allauth/templates/mfa/webauthn/authenticator_list.html
@@ -8,7 +8,7 @@
         {% trans "Security Keys" %}
     {% endelement %}
     {% if authenticators|length == 0 %}
-        <p>{% blocktranslate %}No security keys have been added.{% endblocktranslate %}</p>
+        {% element p %}{% blocktranslate %}No security keys have been added.{% endblocktranslate %}{% endelement %}
     {% else %}
         {% element table %}
             {% element thead %}


### PR DESCRIPTION
# Submitting Pull Requests

!close #4062 Use the p element in passkey-related templates, instead of <p> HTML tags

## General

 - [X] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [X] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [X] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [X] If your changes are significant, please update `ChangeLog.rst`.
 - [X] If your change is substantial, feel free to add yourself to `AUTHORS`.
